### PR TITLE
Fix uglify bug

### DIFF
--- a/config/grunt/uglify.js
+++ b/config/grunt/uglify.js
@@ -14,7 +14,7 @@ module.exports = {
 				dest: 'admin/js/settings.min.js'
 			},
 			{
-				src: 'admin/js/gig-edit.bundle.min.js',
+				src: 'admin/js/gig-edit.bundle.js',
 				dest: 'admin/js/gig-edit.bundle.min.js'
 			},
 			{


### PR DESCRIPTION
the src file gig-edit.bundle.min.js didn't exist, replaced it with gig-edit.bundle.js which does exist after webpack is done compiling